### PR TITLE
Remove height requirement

### DIFF
--- a/packages/workers-og/package.json
+++ b/packages/workers-og/package.json
@@ -13,7 +13,7 @@
     }
   },
   "types": "./dist/index.d.ts",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20231218.0",
     "@types/node": "^20.11.0",

--- a/packages/workers-og/src/og.ts
+++ b/packages/workers-og/src/og.ts
@@ -64,8 +64,8 @@ export const og = async ({ element, options }: Props) => {
     typeof element === "string" ? await parseHtml(element) : element;
 
   // 3. Convert React Element to SVG with Satori
-  const width = options?.width || 1200;
-  const height = options?.height || 630;
+  const width = options?.width;
+  const height = options?.height;
 
   const svg = await satori(reactElement, {
     width,

--- a/packages/workers-og/src/types.ts
+++ b/packages/workers-og/src/types.ts
@@ -4,10 +4,25 @@ type VercelImageResponseOptions = NonNullable<
   ConstructorParameters<typeof ImageResponse>[1]
 >;
 
-export interface ImageResponseOptions extends VercelImageResponseOptions {
+export type ImageResponseOptions = Omit<
+  VercelImageResponseOptions,
+  "width" | "height"
+> & {
   /**
    * The format of the image.
    * @default "png"
    */
   format?: "svg" | "png" | undefined; // Defaults to 'png'
-}
+  /**
+   * The width of the image. If neither width nor height is provided, the default is 1200.
+   *
+   * @type {number}
+   */
+  width?: number;
+  /**
+   * The height of the image. If neither width nor height is provided, the default is 630.
+   *
+   * @type {number}
+   */
+  height?: number;
+};


### PR DESCRIPTION
Satori does not require an explicit height/width. Removing this allows generating an image with a height relative to the HTML content size. Note: if you do this, you can not use `100vh` or `100vw` depending on which dimension you provide or the resulting SVG will be invalid.