### PR TITLE
Export loadGoogleFont to allow custom fonts to be downloaded from google

### DIFF
--- a/packages/workers-og/src/index.ts
+++ b/packages/workers-og/src/index.ts
@@ -1,1 +1,2 @@
 export { ImageResponse } from "./og";
+export { loadGoogleFont } from "./font";


### PR DESCRIPTION
Allows custom fonts to be downloaded from Google Fonts using `loadGoogleFont`. Helps fix #13 